### PR TITLE
Using the 'prop-types' package instead of importing 'PropTypes' from react

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
   },
   "peerDependencies": {
     "react": "*",
-    "redux-saga": "*"
+    "redux-saga": "*",
+    "prop-types": "*"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Children, Component } from 'react'
+import React, { Children, Component } from 'react'
+import PropTypes from 'prop-types';
 
 // top level component
 export class Sagas extends Component {


### PR DESCRIPTION
This PR

- Uses the 'prop-types' package instead of importing 'PropTypes' from react
- Adds the `prop-types` package as a peer dependency